### PR TITLE
Make the executable depend on the generated assets

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -112,4 +112,5 @@ function(rp6502_asset name addr in_file)
             -o "${CMAKE_CURRENT_BINARY_DIR}/${out_file}"
             create "${CMAKE_CURRENT_SOURCE_DIR}/${in_file}"
     )
+    add_dependencies(${name} ${custom_target_name})
 endfunction()


### PR DESCRIPTION
In running cmake on the command line, I noticed the altair example would fail to build.  I think I tracked this down to the tools/CMakeLists.txt.  The custom targets to build the assets were not being set as dependencies of the main executable (so weren't being created by make).  Adding the one line to add the dependency to the executable has fixed building for me.  For reference, I'm building, err, building the build system w/ the following command:
 `mkdir build && cd build && cmake --toolchain ../tools/rp2048.cmake ..`

